### PR TITLE
2: Using a logic level converter instead voltage dividers and transistors

### DIFF
--- a/GenesisController.h
+++ b/GenesisController.h
@@ -2,6 +2,7 @@
 #define __GENESIS_CONTROLLER_H__
 
 #include <stdint.h>
+#include "configuration.h"
 #include "IGenesisControllerObserver.h"
 
 class GenesisController
@@ -84,10 +85,9 @@ class GenesisController
     static const uint8_t NUM_COUNTS = 8;
   private:
     //! Set to true to invert inputs
-    //! @note This assumes external pull-down resistor used when false or pull-up when true
-    static const bool INVERT_INPUTS = false;
+    static const bool INVERT_INPUTS = INVERT_CONTROLLER_INPUTS;
     //! Set to true to invert outputs
-    static const bool INVERT_OUTPUTS = true; // An NPN is used which inverts the output
+    static const bool INVERT_OUTPUTS = INVERT_CONTROLLER_OUTPUTS;
     //! Number of connecting cycles to make before becomming connected
     static const uint8_t MAX_CONNECTING_COUNT = 25;
     //! The ID for this controller

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ controllers to be plugged in and interface with any USB host device.
 ![Schematic](Schematic.png?raw=true)
 
 NOTE: This schematic uses an NPN transistor which inverts the output, so `INVERT_CONTROLLER_OUTPUTS`
-in configuration.h is set to `true`. If you decide to use a logic level converter instead, either
-get one that inverts the output or set `INVERT_CONTROLLER_OUTPUTS` to `false` and recompile.
+in configuration.h is set to `true`. If you decide to use a logic level converter instead, set
+`INVERT_CONTROLLER_OUTPUTS` to `false` and recompile.
 
 A standard male DB9 connector may be used for the controller ports.
 ![DB9 Pinout](db9_pinout.png?raw=true)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ controllers to be plugged in and interface with any USB host device.
 
 ![Schematic](Schematic.png?raw=true)
 
+NOTE: This schematic uses an NPN transistor which inverts the output, so `INVERT_CONTROLLER_OUTPUTS`
+in configuration.h is set to `true`. If you decide to use a logic level converter instead, either
+get one that inverts the output or set `INVERT_CONTROLLER_OUTPUTS` to `false` and recompile.
+
 A standard male DB9 connector may be used for the controller ports.
 ![DB9 Pinout](db9_pinout.png?raw=true)
 

--- a/configuration.h
+++ b/configuration.h
@@ -3,6 +3,12 @@
 
 #include "configuration_constants.h"
 
+// This assumes external pull-down resistor used when false or pull-up when true
+#define INVERT_CONTROLLER_INPUTS false
+
+// An NPN is used in normal schematic which inverts the output, so software should invert
+#define INVERT_CONTROLLER_OUTPUTS true
+
 // Can be either USB_TYPE_KEYBOARD or USB_TYPE_GAMEPAD
 #define PLAYER_1_USB_TYPE     USB_TYPE_GAMEPAD
 


### PR DESCRIPTION
Moved inversion booleans to configuration so their more visible and added note so it's very clear that the design on the readme inverts outputs